### PR TITLE
feat(warga): add jumlah anggota support end-to-end

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { config } from "dotenv";
 import { defineConfig } from "drizzle-kit";
 
-config({ path: ".env.local" });
+config({ path: ".env" });
 
 export default defineConfig({
   dialect: "postgresql",

--- a/drizzle/0003_gray_slayback.sql
+++ b/drizzle/0003_gray_slayback.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "warga" ADD COLUMN "jumlah_anggota" integer DEFAULT 1 NOT NULL;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,803 @@
+{
+  "id": "fcec9a70-6b4d-48e0-a8cd-4f79a1cf8c6e",
+  "prevId": "039da430-cd9a-487b-b23a-53893f163b29",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warga_id": {
+          "name": "warga_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_user_warga_id_nonnull": {
+          "name": "uq_user_warga_id_nonnull",
+          "columns": [
+            {
+              "expression": "warga_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user\".\"warga_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_ck_role": {
+          "name": "user_ck_role",
+          "value": "\"user\".\"role\" in ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kategori_kas": {
+      "name": "kategori_kas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nama_kategori": {
+          "name": "nama_kategori",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jenis_arus": {
+          "name": "jenis_arus",
+          "type": "jenis_arus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipe_tagihan": {
+          "name": "tipe_tagihan",
+          "type": "tipe_tagihan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bulanan'"
+        },
+        "nominal_default": {
+          "name": "nominal_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_aktivitas": {
+      "name": "log_aktivitas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "waktu_log": {
+          "name": "waktu_log",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modul": {
+          "name": "modul",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aksi": {
+          "name": "aksi",
+          "type": "aksi",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keterangan": {
+          "name": "keterangan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "log_aktivitas_user_id_user_id_fk": {
+          "name": "log_aktivitas_user_id_user_id_fk",
+          "tableFrom": "log_aktivitas",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaksi": {
+      "name": "transaksi",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "waktu_transaksi": {
+          "name": "waktu_transaksi",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warga_id": {
+          "name": "warga_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kategori_id": {
+          "name": "kategori_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bulan_tagihan": {
+          "name": "bulan_tagihan",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tahun_tagihan": {
+          "name": "tahun_tagihan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nominal": {
+          "name": "nominal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipe_arus": {
+          "name": "tipe_arus",
+          "type": "tipe_arus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keterangan": {
+          "name": "keterangan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_transaksi_masuk_bulanan": {
+          "name": "uq_transaksi_masuk_bulanan",
+          "columns": [
+            {
+              "expression": "warga_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kategori_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tahun_tagihan",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bulan_tagihan",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transaksi\".\"tipe_arus\" = 'masuk' and \"transaksi\".\"bulan_tagihan\" is not null and \"transaksi\".\"tahun_tagihan\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_transaksi_masuk_sekali": {
+          "name": "uq_transaksi_masuk_sekali",
+          "columns": [
+            {
+              "expression": "warga_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kategori_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transaksi\".\"tipe_arus\" = 'masuk' and \"transaksi\".\"bulan_tagihan\" is null and \"transaksi\".\"tahun_tagihan\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaksi_user_id_user_id_fk": {
+          "name": "transaksi_user_id_user_id_fk",
+          "tableFrom": "transaksi",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "transaksi_warga_id_warga_id_fk": {
+          "name": "transaksi_warga_id_warga_id_fk",
+          "tableFrom": "transaksi",
+          "tableTo": "warga",
+          "columnsFrom": ["warga_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "transaksi_kategori_id_kategori_kas_id_fk": {
+          "name": "transaksi_kategori_id_kategori_kas_id_fk",
+          "tableFrom": "transaksi",
+          "tableTo": "kategori_kas",
+          "columnsFrom": ["kategori_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transaksi_ck_nominal_pos": {
+          "name": "transaksi_ck_nominal_pos",
+          "value": "\"transaksi\".\"nominal\" > 0"
+        },
+        "transaksi_ck_tahun": {
+          "name": "transaksi_ck_tahun",
+          "value": "\"transaksi\".\"tahun_tagihan\" is null or \"transaksi\".\"tahun_tagihan\" between 2000 and 2100"
+        },
+        "transaksi_ck_masuk_keluar_shape": {
+          "name": "transaksi_ck_masuk_keluar_shape",
+          "value": "(\n      (\"transaksi\".\"tipe_arus\" = 'keluar' and \"transaksi\".\"warga_id\" is null and \"transaksi\".\"bulan_tagihan\" is null and \"transaksi\".\"tahun_tagihan\" is null)\n      or\n      (\"transaksi\".\"tipe_arus\" = 'masuk' and \"transaksi\".\"warga_id\" is not null)\n    )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.warga": {
+      "name": "warga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nama_kepala_keluarga": {
+          "name": "nama_kepala_keluarga",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blok_rumah": {
+          "name": "blok_rumah",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "no_telp": {
+          "name": "no_telp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_hunian": {
+          "name": "status_hunian",
+          "type": "status_hunian",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tetap'"
+        },
+        "jumlah_anggota": {
+          "name": "jumlah_anggota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "tgl_batas_domisili": {
+          "name": "tgl_batas_domisili",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tgl_pindah": {
+          "name": "tgl_pindah",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "warga_no_telp_unique": {
+          "name": "warga_no_telp_unique",
+          "nullsNotDistinct": false,
+          "columns": ["no_telp"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "warga_ck_status_domisili": {
+          "name": "warga_ck_status_domisili",
+          "value": "(\n      (\"warga\".\"status_hunian\" = 'tetap' and \"warga\".\"tgl_batas_domisili\" is null)\n      or\n      (\"warga\".\"status_hunian\" = 'kontrak' and \"warga\".\"tgl_batas_domisili\" is not null)\n    )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.jenis_arus": {
+      "name": "jenis_arus",
+      "schema": "public",
+      "values": ["masuk", "keluar"]
+    },
+    "public.tipe_tagihan": {
+      "name": "tipe_tagihan",
+      "schema": "public",
+      "values": ["bulanan", "sekali"]
+    },
+    "public.aksi": {
+      "name": "aksi",
+      "schema": "public",
+      "values": ["tambah", "edit", "hapus", "login", "logout"]
+    },
+    "public.tipe_arus": {
+      "name": "tipe_arus",
+      "schema": "public",
+      "values": ["masuk", "keluar"]
+    },
+    "public.status_hunian": {
+      "name": "status_hunian",
+      "schema": "public",
+      "values": ["tetap", "kontrak"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775988052926,
       "tag": "0002_strange_violations",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1775999451904,
+      "tag": "0003_gray_slayback",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dashboard)/admin/warga/_components/columns.tsx
+++ b/src/app/(dashboard)/admin/warga/_components/columns.tsx
@@ -13,6 +13,7 @@ export interface WargaRow {
   blokRumah: string;
   noTelp: string;
   statusHunian: "tetap" | "kontrak";
+  jumlahAnggota: number;
   tglBatasDomisili: string | null;
   tglPindah: string | null;
   createdAt: Date;
@@ -83,6 +84,11 @@ export function getColumns(onEdit: (row: WargaRow) => void, onDelete: (row: Warg
           {row.original.statusHunian === "tetap" ? "Tetap" : "Kontrak"}
         </Badge>
       ),
+    },
+    {
+      accessorKey: "jumlahAnggota",
+      header: "Jml. Anggota",
+      cell: ({ row }) => <span>{row.original.jumlahAnggota} Orang</span>,
     },
     {
       accessorKey: "tglPindah",

--- a/src/app/(dashboard)/admin/warga/_components/warga-form.tsx
+++ b/src/app/(dashboard)/admin/warga/_components/warga-form.tsx
@@ -27,13 +27,14 @@ interface WargaFormProps {
 export function WargaForm({ open, onOpenChange, editData, onSuccess }: WargaFormProps) {
   const isEdit = !!editData;
 
-  const form = useForm<WargaFormValues>({
-    resolver: zodResolver(wargaFormSchema),
+  const form = useForm<WargaFormValues, unknown, WargaFormValues>({
+    resolver: zodResolver(wargaFormSchema) as never,
     defaultValues: {
       namaKepalaKeluarga: "",
       blokRumah: "",
       noTelp: "",
       statusHunian: "tetap",
+      jumlahAnggota: 1,
       tglBatasDomisili: undefined,
       tglPindah: undefined,
       isAdmin: false,
@@ -50,6 +51,7 @@ export function WargaForm({ open, onOpenChange, editData, onSuccess }: WargaForm
           blokRumah: editData.blokRumah,
           noTelp: editData.noTelp,
           statusHunian: editData.statusHunian,
+          jumlahAnggota: editData.jumlahAnggota ?? 1,
           tglBatasDomisili: editData.tglBatasDomisili ?? undefined,
           tglPindah: editData.tglPindah ?? undefined,
           isAdmin: editData.isAdmin ?? false,
@@ -60,6 +62,7 @@ export function WargaForm({ open, onOpenChange, editData, onSuccess }: WargaForm
           blokRumah: "",
           noTelp: "",
           statusHunian: "tetap",
+          jumlahAnggota: 1,
           tglBatasDomisili: undefined,
           tglPindah: undefined,
           isAdmin: false,
@@ -133,6 +136,20 @@ export function WargaForm({ open, onOpenChange, editData, onSuccess }: WargaForm
                     <FormLabel>No. Telepon / WhatsApp</FormLabel>
                     <FormControl>
                       <Input placeholder="081234567890" type="tel" inputMode="numeric" autoComplete="tel" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="jumlahAnggota"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Jumlah Anggota Keluarga</FormLabel>
+                    <FormControl>
+                      <Input type="number" min={1} placeholder="1" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/db/schema/warga.ts
+++ b/src/db/schema/warga.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { check, date, pgEnum, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { check, date, integer, pgEnum, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
 
 export const statusHunianEnum = pgEnum("status_hunian", ["tetap", "kontrak"]);
 
@@ -11,6 +11,7 @@ export const warga = pgTable(
     blokRumah: text("blok_rumah").notNull(),
     noTelp: text("no_telp").notNull().unique(),
     statusHunian: statusHunianEnum("status_hunian").notNull().default("tetap"),
+    jumlahAnggota: integer("jumlah_anggota").notNull().default(1),
     tglBatasDomisili: date("tgl_batas_domisili"),
     tglPindah: date("tgl_pindah"),
     createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/src/lib/validations/warga.ts
+++ b/src/lib/validations/warga.ts
@@ -5,6 +5,7 @@ export const wargaFormSchema = z.object({
   blokRumah: z.string().min(1, "Blok rumah wajib diisi"),
   noTelp: z.string().min(10, "Nomor telepon minimal 10 digit").max(15),
   statusHunian: z.enum(["tetap", "kontrak"]),
+  jumlahAnggota: z.coerce.number().int().min(1, "Jumlah anggota KK minimal 1 orang"),
   tglBatasDomisili: z.string().optional().nullable(),
   tglPindah: z.string().optional().nullable(),
   isAdmin: z.boolean(),

--- a/src/server/actions/warga.ts
+++ b/src/server/actions/warga.ts
@@ -34,6 +34,7 @@ export async function getWargaList(search?: string) {
       blokRumah: warga.blokRumah,
       noTelp: warga.noTelp,
       statusHunian: warga.statusHunian,
+      jumlahAnggota: warga.jumlahAnggota,
       tglBatasDomisili: warga.tglBatasDomisili,
       tglPindah: warga.tglPindah,
       createdAt: warga.createdAt,
@@ -55,6 +56,7 @@ export async function getWargaById(id: number) {
       blokRumah: warga.blokRumah,
       noTelp: warga.noTelp,
       statusHunian: warga.statusHunian,
+      jumlahAnggota: warga.jumlahAnggota,
       tglBatasDomisili: warga.tglBatasDomisili,
       tglPindah: warga.tglPindah,
       createdAt: warga.createdAt,
@@ -85,6 +87,7 @@ export async function createWarga(data: WargaFormValues) {
         blokRumah: parsed.blokRumah,
         noTelp: parsed.noTelp,
         statusHunian: parsed.statusHunian,
+        jumlahAnggota: parsed.jumlahAnggota,
         tglBatasDomisili: parsed.tglBatasDomisili ?? null,
         tglPindah: parsed.tglPindah ?? null,
       })
@@ -173,6 +176,7 @@ export async function updateWarga(id: number, data: WargaFormValues) {
         blokRumah: parsed.blokRumah,
         noTelp: parsed.noTelp,
         statusHunian: parsed.statusHunian,
+        jumlahAnggota: parsed.jumlahAnggota,
         tglBatasDomisili: parsed.tglBatasDomisili ?? null,
         tglPindah: parsed.tglPindah ?? null,
       })


### PR DESCRIPTION
## Summary
- Add `jumlahAnggota` support across Warga flow from Drizzle schema, migration, and server actions to form validation and UI table display.
- Add new `jumlah_anggota` database migration and metadata snapshots so schema changes are tracked and reproducible.
- Align Drizzle config to load `.env` so migration commands target the same database used by the app runtime.

## Verification
- `npm run db:migrate`
- `npm run build`