### PR TITLE
fix(core): resolve issue #22 bug backlog across auth and reporting

### DIFF
--- a/src/app/api/laporan/excel/route.ts
+++ b/src/app/api/laporan/excel/route.ts
@@ -2,23 +2,9 @@ import type { NextRequest } from "next/server";
 
 import { requireAdmin } from "@/lib/auth-helpers";
 import { generateExcelBuffer } from "@/lib/excel/export-helpers";
+import { BULAN_NAMES } from "@/lib/utils";
 import { laporanParamsSchema } from "@/lib/validations/laporan";
 import { getRekapKas } from "@/server/actions/laporan";
-
-const BULAN_NAMES = [
-  "Januari",
-  "Februari",
-  "Maret",
-  "April",
-  "Mei",
-  "Juni",
-  "Juli",
-  "Agustus",
-  "September",
-  "Oktober",
-  "November",
-  "Desember",
-] as const;
 
 export async function GET(request: NextRequest) {
   await requireAdmin();

--- a/src/lib/validations/warga.ts
+++ b/src/lib/validations/warga.ts
@@ -1,14 +1,24 @@
 import { z } from "zod";
 
-export const wargaFormSchema = z.object({
-  namaKepalaKeluarga: z.string().min(1, "Nama wajib diisi"),
-  blokRumah: z.string().min(1, "Blok rumah wajib diisi"),
-  noTelp: z.string().min(10, "Nomor telepon minimal 10 digit").max(15),
-  statusHunian: z.enum(["tetap", "kontrak"]),
-  jumlahAnggota: z.coerce.number().int().min(1, "Jumlah anggota KK minimal 1 orang"),
-  tglBatasDomisili: z.string().optional().nullable(),
-  tglPindah: z.string().optional().nullable(),
-  isAdmin: z.boolean(),
-});
+export const wargaFormSchema = z
+  .object({
+    namaKepalaKeluarga: z.string().min(1, "Nama wajib diisi"),
+    blokRumah: z.string().min(1, "Blok rumah wajib diisi"),
+    noTelp: z.string().min(10, "Nomor telepon minimal 10 digit").max(15),
+    statusHunian: z.enum(["tetap", "kontrak"]),
+    jumlahAnggota: z.coerce.number().int().min(1, "Jumlah anggota KK minimal 1 orang"),
+    tglBatasDomisili: z.string().optional().nullable(),
+    tglPindah: z.string().optional().nullable(),
+    isAdmin: z.boolean(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.statusHunian === "kontrak" && !data.tglBatasDomisili) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["tglBatasDomisili"],
+        message: "Tanggal batas domisili wajib diisi untuk warga kontrak",
+      });
+    }
+  });
 
 export type WargaFormValues = z.infer<typeof wargaFormSchema>;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,13 +3,28 @@ import { NextResponse } from "next/server";
 
 import { getSessionCookie } from "better-auth/cookies";
 
+import { auth } from "@/lib/auth";
+
 export async function proxy(request: NextRequest) {
   const sessionCookie = getSessionCookie(request);
   const { pathname } = request.nextUrl;
+  const isAdminRoute = pathname.startsWith("/admin");
+  const isWargaRoute = pathname.startsWith("/warga");
 
   // Redirect unauthenticated users to login
-  if (!sessionCookie && (pathname.startsWith("/admin") || pathname.startsWith("/warga"))) {
+  if (!sessionCookie && (isAdminRoute || isWargaRoute)) {
     return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  if (sessionCookie && (isAdminRoute || isWargaRoute)) {
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session) {
+      return NextResponse.redirect(new URL("/login", request.url));
+    }
+
+    if (isAdminRoute && session.user.role !== "admin") {
+      return NextResponse.redirect(new URL("/unauthorized", request.url));
+    }
   }
 
   return NextResponse.next();

--- a/src/server/actions/kas-masuk.ts
+++ b/src/server/actions/kas-masuk.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
-import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, sql } from "drizzle-orm";
 
 import { db } from "@/db";
 import { kategoriKas, transaksi, warga } from "@/db/schema";
@@ -12,96 +12,145 @@ import { type KasMasukFormValues, kasMasukFormSchema } from "@/lib/validations/k
 
 import { logActivity } from "./audit";
 
+function isUniqueViolation(error: unknown): error is { code: string } {
+  return (
+    typeof error === "object" && error !== null && "code" in error && (error as { code?: string }).code === "23505"
+  );
+}
+
 export async function createPembayaran(data: KasMasukFormValues) {
   const session = await requireAdmin();
   const parsed = kasMasukFormSchema.parse(data);
 
-  const [wargaData] = await db.select().from(warga).where(eq(warga.id, parsed.wargaId));
-  const [kategoriData] = await db.select().from(kategoriKas).where(eq(kategoriKas.id, parsed.kategoriId));
+  interface CreatePembayaranResult {
+    inserted: (typeof transaksi.$inferSelect)[];
+    wargaData: typeof warga.$inferSelect;
+    kategoriData: typeof kategoriKas.$inferSelect;
+    activityText: string;
+  }
 
-  if (!wargaData || !kategoriData) throw new Error("Data tidak valid");
+  let result: CreatePembayaranResult;
 
-  const isSekali = parsed.bulanTagihan.length === 0;
+  try {
+    result = await db.transaction(async (tx) => {
+      const [wargaData] = await tx.select().from(warga).where(eq(warga.id, parsed.wargaId));
+      const [kategoriData] = await tx.select().from(kategoriKas).where(eq(kategoriKas.id, parsed.kategoriId));
 
-  if (isSekali) {
-    // One-time payment: insert a single transaction with null bulanTagihan and null tahunTagihan
-    const [inserted] = await db
-      .insert(transaksi)
-      .values({
-        userId: session.user.id,
-        wargaId: parsed.wargaId,
-        kategoriId: parsed.kategoriId,
-        bulanTagihan: null,
-        tahunTagihan: null,
-        nominal: parsed.nominal,
-        tipeArus: "masuk" as const,
-        keterangan: parsed.keterangan ?? `${kategoriData.namaKategori} — ${wargaData.namaKepalaKeluarga}`,
-      })
-      .returning();
+      if (!wargaData || !kategoriData) throw new Error("Data tidak valid");
 
-    if (!inserted) throw new Error("Gagal menyimpan transaksi");
+      const isSekali = parsed.bulanTagihan.length === 0;
 
-    await logActivity({
-      userId: session.user.id,
-      modul: "Kas Masuk",
-      aksi: "tambah",
-      keterangan: `Mencatat iuran ${kategoriData.namaKategori} Rp ${parsed.nominal.toLocaleString("id-ID")} (sekali bayar) untuk ${wargaData.namaKepalaKeluarga} (${wargaData.blokRumah})`,
+      if (isSekali) {
+        const [existingSekali] = await tx
+          .select({ id: transaksi.id })
+          .from(transaksi)
+          .where(
+            and(
+              eq(transaksi.wargaId, parsed.wargaId),
+              eq(transaksi.kategoriId, parsed.kategoriId),
+              eq(transaksi.tipeArus, "masuk"),
+              isNull(transaksi.bulanTagihan),
+              isNull(transaksi.tahunTagihan),
+            ),
+          )
+          .limit(1);
+
+        if (existingSekali) {
+          throw new Error(
+            `${wargaData.namaKepalaKeluarga} sudah membayar ${kategoriData.namaKategori} (sekali bayar) sebelumnya`,
+          );
+        }
+
+        const [inserted] = await tx
+          .insert(transaksi)
+          .values({
+            userId: session.user.id,
+            wargaId: parsed.wargaId,
+            kategoriId: parsed.kategoriId,
+            bulanTagihan: null,
+            tahunTagihan: null,
+            nominal: parsed.nominal,
+            tipeArus: "masuk" as const,
+            keterangan: parsed.keterangan ?? `${kategoriData.namaKategori} — ${wargaData.namaKepalaKeluarga}`,
+          })
+          .returning();
+
+        if (!inserted) throw new Error("Gagal menyimpan transaksi");
+
+        return {
+          inserted: [inserted],
+          wargaData,
+          kategoriData,
+          activityText: `Mencatat iuran ${kategoriData.namaKategori} Rp ${parsed.nominal.toLocaleString("id-ID")} (sekali bayar) untuk ${wargaData.namaKepalaKeluarga} (${wargaData.blokRumah})`,
+        };
+      }
+
+      const existing = await tx
+        .select({ bulanTagihan: transaksi.bulanTagihan })
+        .from(transaksi)
+        .where(
+          and(
+            eq(transaksi.wargaId, parsed.wargaId),
+            eq(transaksi.kategoriId, parsed.kategoriId),
+            eq(transaksi.tahunTagihan, parsed.tahunTagihan),
+            eq(transaksi.tipeArus, "masuk"),
+            inArray(transaksi.bulanTagihan, parsed.bulanTagihan),
+          ),
+        );
+
+      if (existing.length > 0) {
+        const duplicateBulans = existing.map((e) => e.bulanTagihan).join(", ");
+        throw new Error(
+          `${wargaData.namaKepalaKeluarga} sudah membayar ${kategoriData.namaKategori} untuk bulan: ${duplicateBulans} tahun ${parsed.tahunTagihan}`,
+        );
+      }
+
+      const inserted = await tx
+        .insert(transaksi)
+        .values(
+          parsed.bulanTagihan.map((bulan) => ({
+            userId: session.user.id,
+            wargaId: parsed.wargaId,
+            kategoriId: parsed.kategoriId,
+            bulanTagihan: bulan,
+            tahunTagihan: parsed.tahunTagihan,
+            nominal: parsed.nominal,
+            tipeArus: "masuk" as const,
+            keterangan: parsed.keterangan ?? `Iuran ${kategoriData.namaKategori} bulan ${bulan} ${parsed.tahunTagihan}`,
+          })),
+        )
+        .returning();
+
+      const bulanStr = parsed.bulanTagihan.join(", ");
+      return {
+        inserted,
+        wargaData,
+        kategoriData,
+        activityText: `Mencatat iuran ${kategoriData.namaKategori} Rp ${parsed.nominal.toLocaleString("id-ID")} untuk ${wargaData.namaKepalaKeluarga} (${wargaData.blokRumah}) bulan ${bulanStr} ${parsed.tahunTagihan}`,
+      };
     });
-
-    revalidatePath("/admin/kas-masuk");
-
-    return { inserted: [inserted], refNumber: generateRefNumber(), wargaData, kategoriData };
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new Error("Pembayaran duplikat terdeteksi untuk kategori dan periode yang sama.");
+    }
+    throw error;
   }
 
-  // Check for duplicate: find which selected months already have a record
-  const existing = await db
-    .select({ bulanTagihan: transaksi.bulanTagihan })
-    .from(transaksi)
-    .where(
-      and(
-        eq(transaksi.wargaId, parsed.wargaId),
-        eq(transaksi.kategoriId, parsed.kategoriId),
-        eq(transaksi.tahunTagihan, parsed.tahunTagihan),
-        eq(transaksi.tipeArus, "masuk"),
-        inArray(transaksi.bulanTagihan, parsed.bulanTagihan),
-      ),
-    );
-
-  if (existing.length > 0) {
-    const duplicateBulans = existing.map((e) => e.bulanTagihan).join(", ");
-    throw new Error(
-      `${wargaData.namaKepalaKeluarga} sudah membayar ${kategoriData.namaKategori} untuk bulan: ${duplicateBulans} tahun ${parsed.tahunTagihan}`,
-    );
-  }
-
-  // Insert one transaction per selected month
-  const inserted = await db
-    .insert(transaksi)
-    .values(
-      parsed.bulanTagihan.map((bulan) => ({
-        userId: session.user.id,
-        wargaId: parsed.wargaId,
-        kategoriId: parsed.kategoriId,
-        bulanTagihan: bulan,
-        tahunTagihan: parsed.tahunTagihan,
-        nominal: parsed.nominal,
-        tipeArus: "masuk" as const,
-        keterangan: parsed.keterangan ?? `Iuran ${kategoriData.namaKategori} bulan ${bulan} ${parsed.tahunTagihan}`,
-      })),
-    )
-    .returning();
-
-  const bulanStr = parsed.bulanTagihan.join(", ");
   await logActivity({
     userId: session.user.id,
     modul: "Kas Masuk",
     aksi: "tambah",
-    keterangan: `Mencatat iuran ${kategoriData.namaKategori} Rp ${parsed.nominal.toLocaleString("id-ID")} untuk ${wargaData.namaKepalaKeluarga} (${wargaData.blokRumah}) bulan ${bulanStr} ${parsed.tahunTagihan}`,
+    keterangan: result.activityText,
   });
 
   revalidatePath("/admin/kas-masuk");
 
-  return { inserted, refNumber: generateRefNumber(), wargaData, kategoriData };
+  return {
+    inserted: result.inserted,
+    refNumber: generateRefNumber(),
+    wargaData: result.wargaData,
+    kategoriData: result.kategoriData,
+  };
 }
 
 export async function getRecentPemasukan() {

--- a/src/server/actions/kategori-kas.ts
+++ b/src/server/actions/kategori-kas.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { db } from "@/db";
 import { kategoriKas, transaksi } from "@/db/schema";
@@ -79,11 +79,10 @@ export async function deleteKategori(id: number) {
 
   // Block deletion if referenced by transactions
   const [usage] = await db
-    .select({ count: eq(transaksi.kategoriId, id) })
+    .select({ count: sql<number>`count(*)::int` })
     .from(transaksi)
-    .where(eq(transaksi.kategoriId, id))
-    .limit(1);
-  if (usage) throw new Error("Kategori ini sudah digunakan dalam transaksi dan tidak bisa dihapus");
+    .where(eq(transaksi.kategoriId, id));
+  if (usage && usage.count > 0) throw new Error("Kategori ini sudah digunakan dalam transaksi dan tidak bisa dihapus");
 
   await db.delete(kategoriKas).where(eq(kategoriKas.id, id));
   await logActivity({

--- a/src/server/actions/laporan.ts
+++ b/src/server/actions/laporan.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { and, asc, eq, gte, lt, lte, sql } from "drizzle-orm";
+import { and, asc, eq, gte, lt, sql } from "drizzle-orm";
 
 import { db } from "@/db";
 import { kategoriKas, transaksi, warga } from "@/db/schema";
@@ -38,7 +38,7 @@ export async function getRekapKas(bulanAwal: number, bulanAkhir: number, tahun: 
     .from(transaksi)
     .leftJoin(kategoriKas, eq(transaksi.kategoriId, kategoriKas.id))
     .leftJoin(warga, eq(transaksi.wargaId, warga.id))
-    .where(and(gte(transaksi.waktuTransaksi, startDate), lte(transaksi.waktuTransaksi, endDate)))
+    .where(and(gte(transaksi.waktuTransaksi, startDate), lt(transaksi.waktuTransaksi, endDate)))
     .orderBy(asc(transaksi.waktuTransaksi));
 }
 
@@ -54,7 +54,7 @@ export async function getRekapSummary(bulanAwal: number, bulanAkhir: number, tah
       and(
         eq(transaksi.tipeArus, "masuk"),
         gte(transaksi.waktuTransaksi, startDate),
-        lte(transaksi.waktuTransaksi, endDate),
+        lt(transaksi.waktuTransaksi, endDate),
       ),
     );
 
@@ -65,7 +65,7 @@ export async function getRekapSummary(bulanAwal: number, bulanAkhir: number, tah
       and(
         eq(transaksi.tipeArus, "keluar"),
         gte(transaksi.waktuTransaksi, startDate),
-        lte(transaksi.waktuTransaksi, endDate),
+        lt(transaksi.waktuTransaksi, endDate),
       ),
     );
 
@@ -118,7 +118,7 @@ export async function getMonthlyChartData(tahun: number) {
       total: sql<number>`sum(${transaksi.nominal})::int`,
     })
     .from(transaksi)
-    .where(and(gte(transaksi.waktuTransaksi, startDate), lte(transaksi.waktuTransaksi, endDate)))
+    .where(and(gte(transaksi.waktuTransaksi, startDate), lt(transaksi.waktuTransaksi, endDate)))
     .groupBy(sql`extract(month from ${transaksi.waktuTransaksi})`, transaksi.tipeArus);
 
   // Build 12-month array

--- a/src/server/actions/tunggakan.ts
+++ b/src/server/actions/tunggakan.ts
@@ -58,7 +58,7 @@ export async function getTunggakan(filters: TunggakanFilters): Promise<Tunggakan
       })
       .from(warga)
       .leftJoin(transaksi, joinConditionSekali)
-      .where(isNull(transaksi.id))
+      .where(and(isNull(transaksi.id), isNull(warga.tglPindah)))
       .orderBy(warga.blokRumah, warga.namaKepalaKeluarga);
 
     return rows.map((row) => ({
@@ -93,7 +93,8 @@ export async function getTunggakan(filters: TunggakanFilters): Promise<Tunggakan
     })
     .from(warga)
     .leftJoin(transaksi, joinConditionBulanan)
-    .groupBy(warga.id)
+    .where(isNull(warga.tglPindah))
+    .groupBy(warga.id, warga.namaKepalaKeluarga, warga.blokRumah, warga.noTelp, warga.statusHunian)
     .orderBy(warga.blokRumah, warga.namaKepalaKeluarga);
 
   const totalPeriods = periods.length;

--- a/src/server/actions/warga-dashboard.ts
+++ b/src/server/actions/warga-dashboard.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 
 import { db } from "@/db";
 import { kategoriKas, transaksi, warga } from "@/db/schema";
@@ -95,11 +95,11 @@ export async function getBillingStatus(month: number, year: number): Promise<Bil
       ),
     );
 
-  // Fetch sekali-bayar payments (no month/year filter — just wargaId + kategoriId)
+  // Fetch sekali-bayar payments (filter only one-time entries)
   const sekaliPayments = await db
     .select({ id: transaksi.id, kategoriId: transaksi.kategoriId })
     .from(transaksi)
-    .where(and(eq(transaksi.wargaId, wargaId), eq(transaksi.tipeArus, "masuk")));
+    .where(and(eq(transaksi.wargaId, wargaId), eq(transaksi.tipeArus, "masuk"), isNull(transaksi.bulanTagihan)));
 
   return categories.map((kat) => {
     const payments = kat.tipeTagihan === "sekali" ? sekaliPayments : bulananPayments;

--- a/src/server/actions/warga-riwayat.ts
+++ b/src/server/actions/warga-riwayat.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, isNull } from "drizzle-orm";
 
 import { db } from "@/db";
 import { kategoriKas, transaksi, user, warga } from "@/db/schema";
@@ -77,7 +77,7 @@ export async function getPaymentGrid(bulan: number, tahun: number): Promise<Paym
     )
     .orderBy(asc(transaksi.waktuTransaksi));
 
-  // Sekali-bayar payments (no year/bulan filter)
+  // Sekali-bayar payments (filter only one-time entries)
   const sekaliPayments = await db
     .select({
       id: transaksi.id,
@@ -86,7 +86,7 @@ export async function getPaymentGrid(bulan: number, tahun: number): Promise<Paym
       waktuTransaksi: transaksi.waktuTransaksi,
     })
     .from(transaksi)
-    .where(and(eq(transaksi.wargaId, wargaId), eq(transaksi.tipeArus, "masuk")));
+    .where(and(eq(transaksi.wargaId, wargaId), eq(transaksi.tipeArus, "masuk"), isNull(transaksi.bulanTagihan)));
 
   return categories.map((kat): PaymentGridByKategori => {
     if (kat.tipeTagihan === "sekali") {

--- a/src/server/actions/warga.ts
+++ b/src/server/actions/warga.ts
@@ -122,12 +122,16 @@ export async function createWarga(data: WargaFormValues) {
     return { ...newWarga, defaultPassword: parsed.noTelp };
   });
 
-  await logActivity({
-    userId: session.user.id,
-    modul: "Data Warga",
-    aksi: "tambah",
-    keterangan: `Menambahkan warga baru an. ${parsed.namaKepalaKeluarga} (${parsed.blokRumah})`,
-  });
+  try {
+    await logActivity({
+      userId: session.user.id,
+      modul: "Data Warga",
+      aksi: "tambah",
+      keterangan: `Menambahkan warga baru an. ${parsed.namaKepalaKeluarga} (${parsed.blokRumah})`,
+    });
+  } catch {
+    // Do not fail primary transaction when audit logging fails
+  }
   revalidatePath("/admin/warga");
 
   return result;
@@ -186,12 +190,16 @@ export async function updateWarga(id: number, data: WargaFormValues) {
     return updatedResult;
   });
 
-  await logActivity({
-    userId: session.user.id,
-    modul: "Data Warga",
-    aksi: "edit",
-    keterangan: `Mengubah data warga an. ${parsed.namaKepalaKeluarga} (${parsed.blokRumah})`,
-  });
+  try {
+    await logActivity({
+      userId: session.user.id,
+      modul: "Data Warga",
+      aksi: "edit",
+      keterangan: `Mengubah data warga an. ${parsed.namaKepalaKeluarga} (${parsed.blokRumah})`,
+    });
+  } catch {
+    // Do not fail primary transaction when audit logging fails
+  }
   revalidatePath("/admin/warga");
 
   return updated;
@@ -213,7 +221,12 @@ export async function deleteWarga(id: number) {
   }
 
   await db.transaction(async (tx) => {
-    // Delete linked user account (sessions cascade via FK)
+    const linkedUsers = await tx.select({ id: user.id }).from(user).where(eq(user.wargaId, id));
+
+    for (const linkedUser of linkedUsers) {
+      await tx.delete(account).where(eq(account.userId, linkedUser.id));
+    }
+
     await tx.delete(user).where(eq(user.wargaId, id));
     await tx.delete(warga).where(eq(warga.id, id));
   });


### PR DESCRIPTION
## Summary
- Fix critical data integrity issues in kategori and warga deletion flows by using proper transaction usage checks and deleting dependent auth account records before user deletion.
- Improve reporting and billing correctness by fixing end-date boundaries, filtering sekali bayar queries to one-time transactions only, and excluding moved residents from tunggakan aggregation with explicit grouped columns.
- Harden authorization and validation by adding admin role checks in proxy, enforcing kontrak domicile date validation in Zod, and reducing payment race conditions by wrapping duplicate checks + inserts in a single transaction with friendly duplicate errors.

## Verification
- `npx biome check "src/app/api/laporan/excel/route.ts" "src/lib/validations/warga.ts" "src/proxy.ts" "src/server/actions/kas-masuk.ts" "src/server/actions/kategori-kas.ts" "src/server/actions/laporan.ts" "src/server/actions/tunggakan.ts" "src/server/actions/warga-dashboard.ts" "src/server/actions/warga-riwayat.ts" "src/server/actions/warga.ts"`
- `npm run build`